### PR TITLE
Check for defaultPrevented

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var url = require('url');
 
 module.exports = function (root, cb) {
     root.addEventListener('click', function (ev) {
-        if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey) {
+        if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey || ev.defaultPrevented) {
             return true;
         }
         

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function (root, cb) {
         
         var anchor = null;
         for (var n = ev.target; n.parentNode; n = n.parentNode) {
-            if (n.tagName && n.tagName.toUpperCase() === 'A') {
+            if (n.nodeName === 'A') {
                 anchor = n;
                 break;
             }


### PR DESCRIPTION
Added check for defaultPrevented, because you probably don't want to call the callback (for example, doing a push-state) if the default was already prevented.  Alternatively, you could return the event object so that it the callback could make this determination for itself (ie. `cb(url.resolve(location.href, href), ev);`