### PR TITLE
Route only option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,32 +1,32 @@
 var url = require('url');
 
 module.exports = function (root, cb, rel) {
-    root.addEventListener('click', function (ev) {
-        if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey || ev.defaultPrevented) {
-            return true;
-        }
+	root.addEventListener('click', function (ev) {
+		if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey || ev.defaultPrevented) {
+			return true;
+		}
 
-        var anchor = null;
-        for (var n = ev.target; n.parentNode; n = n.parentNode) {
-            if (n.nodeName === 'A') {
-                anchor = n;
-                break;
-            }
-        }
-        if (!anchor) return true;
+		var anchor = null;
+		for (var n = ev.target; n.parentNode; n = n.parentNode) {
+			if (n.nodeName === 'A') {
+				anchor = n;
+				break;
+			}
+		}
+		if (!anchor) return true;
 
-        var href = anchor.getAttribute('href');
-        var u = url.parse(anchor.getAttribute('href'));
+		var href = anchor.getAttribute('href');
+		var u = url.parse(anchor.getAttribute('href'));
 
-        if (u.host && u.host !== location.host) return true;
+		if (u.host && u.host !== location.host) return true;
 
-        ev.preventDefault();
+		ev.preventDefault();
 
-        var link = rel === true
-            ? u.path + (u.hash || '')
-            : url.resolve(location.href, href);
+		var link = rel === true
+			? u.path + (u.hash || '')
+			: url.resolve(location.href, href);
 
-        cb(link);
-        return false;
-    });
+		cb(link);
+		return false;
+	});
 };

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 var url = require('url');
 
-module.exports = function (root, cb) {
+module.exports = function (root, cb, rel) {
     root.addEventListener('click', function (ev) {
         if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey || ev.defaultPrevented) {
             return true;
         }
-        
+
         var anchor = null;
         for (var n = ev.target; n.parentNode; n = n.parentNode) {
             if (n.nodeName === 'A') {
@@ -14,14 +14,19 @@ module.exports = function (root, cb) {
             }
         }
         if (!anchor) return true;
-        
+
         var href = anchor.getAttribute('href');
         var u = url.parse(anchor.getAttribute('href'));
-        
+
         if (u.host && u.host !== location.host) return true;
-        
+
         ev.preventDefault();
-        cb(url.resolve(location.href, href));
+
+        var link = rel === true
+            ? u.path + (u.hash || '')
+            : url.resolve(location.href, href);
+
+        cb(link);
         return false;
     });
 };

--- a/index.js
+++ b/index.js
@@ -1,32 +1,32 @@
 var url = require('url');
 
 module.exports = function (root, cb, rel) {
-	root.addEventListener('click', function (ev) {
-		if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey || ev.defaultPrevented) {
-			return true;
-		}
+    root.addEventListener('click', function (ev) {
+        if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey || ev.defaultPrevented) {
+            return true;
+        }
 
-		var anchor = null;
-		for (var n = ev.target; n.parentNode; n = n.parentNode) {
-			if (n.nodeName === 'A') {
-				anchor = n;
-				break;
-			}
-		}
-		if (!anchor) return true;
+        var anchor = null;
+        for (var n = ev.target; n.parentNode; n = n.parentNode) {
+            if (n.nodeName === 'A') {
+                anchor = n;
+                break;
+            }
+        }
+        if (!anchor) return true;
 
-		var href = anchor.getAttribute('href');
-		var u = url.parse(anchor.getAttribute('href'));
+        var href = anchor.getAttribute('href');
+        var u = url.parse(anchor.getAttribute('href'));
 
-		if (u.host && u.host !== location.host) return true;
+        if (u.host && u.host !== location.host) return true;
 
-		ev.preventDefault();
+        ev.preventDefault();
 
-		var link = rel === true
-			? u.path + (u.hash || '')
-			: url.resolve(location.href, href);
+        var link = rel === true
+            ? u.path + (u.hash || '')
+            : url.resolve(location.href, href);
 
-		cb(link);
-		return false;
-	});
+        cb(link);
+        return false;
+    });
 };

--- a/readme.markdown
+++ b/readme.markdown
@@ -28,8 +28,7 @@ Given some html:
 </html>
 ```
 
-We'll intercept the relative links `/a` and `/b`, printing them. The external
-link to npmjs.org will go through as usual.
+We'll intercept the relative links `<host>/a` and `<host>/b`, printing them. The external link to npmjs.org will go through as usual.
 
 ``` js
 var catchLinks = require('catch-links');
@@ -45,10 +44,9 @@ catchLinks(window, function (href) {
 var catchLinks = require('catch-links')
 ```
 
-## catchLinks(element, cb)
+## catchLinks(element, cb, [route])
 
-Fire `cb(href)` whenever an anchor tag descendant of `element` with an in-server
-url is clicked.
+Fire `cb(href)` whenever an anchor tag descendant of `element` with an in-server url is clicked. If `route` is `true`, only the route portion of `href` with be passed to `cb`.
 
 # install
 


### PR DESCRIPTION
The readme currently implies that you get the `href` attribute from the clicked anchor, which would be useful. But you actually get the fully resolved URL. With a `route` flag, you can receive just the part of URL that your pushState router cares about.