### PR TITLE
When catching internal links, make sure internal link protocol is `http:` or `https:`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function (root, cb) {
         if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey || ev.defaultPrevented) {
             return true;
         }
-        
+
         var anchor = null;
         for (var n = ev.target; n.parentNode; n = n.parentNode) {
             if (n.nodeName === 'A') {
@@ -14,16 +14,19 @@ module.exports = function (root, cb) {
             }
         }
         if (!anchor) return true;
-        
+
         var href = anchor.getAttribute('href');
         var u = url.parse(anchor.getAttribute('href'));
-        
-        if (u.host && u.host !== location.host) return true;
-        
+
+        if (u.host && (
+          (u.protocol.match(/https?:/) && (u.host !== location.host)) ||
+          (!u.protocol.match(/https?:/))
+        )) return true;
+
         ev.preventDefault();
-        
+
         var base = location.protocol + '//' + location.host;
-        
+
         cb(url.resolve(location.pathname, u.path || '') + (u.hash || ''));
         return false;
     });


### PR DESCRIPTION
When catching internal links, make sure internal link protocol is `http:` or `https:`.

`mailto:` links to email addresses at the same hostname as the source webserver were accidentally getting caught, etc.

thanks!
cc @substack @jackmoore @yamadapc
