### PR TITLE
Remove url module dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-module.exports = function (root, cb) {
-    root.addEventListener('click', function (ev) {
+module.exports = function (cb) {    
+    return function (ev) {
         if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey || ev.defaultPrevented) {
             return true;
         }
@@ -11,6 +11,7 @@ module.exports = function (root, cb) {
                 break;
             }
         }
+
         if (!anchor) return true;
 
         // IE clears the host value if the anchor href changed after creation, e.g. in React
@@ -31,5 +32,5 @@ module.exports = function (root, cb) {
         
         cb(anchor.href);
         return false;
-    });
+    };
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var url = require('url');
-
 module.exports = function (root, cb) {
     root.addEventListener('click', function (ev) {
         if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey || ev.defaultPrevented) {
@@ -15,13 +13,23 @@ module.exports = function (root, cb) {
         }
         if (!anchor) return true;
 
-        var u = url.parse(anchor.getAttribute('href'));
+        // IE clears the host value if the anchor href changed after creation, e.g. in React
+        // Creating a new anchor element to insure host value is present
+        var a1 = document.createElement('a');
+        a1.href = anchor.href;
         
-        if (u.host && u.host !== location.host) return true;
+        // In IE, the default port is included in the anchor host but excluded from the location host.
+        // This affects the ability to directly compare location host to anchor host.
+        // For example: http://example.com would have a location.host of 'example.com' and an anchor.host of 'example.com:80'
+        // Creating anchor from the location.href to normalize the host value.
+        var a2 = document.createElement('a');
+        a2.href = location.href;
+
+        if (a1.host !== a2.host) return true;
         
         ev.preventDefault();
         
-        cb(url.resolve(location.pathname, u.path || '') + (u.hash || ''));
+        cb(anchor.href);
         return false;
     });
 };

--- a/index.js
+++ b/index.js
@@ -14,15 +14,12 @@ module.exports = function (root, cb) {
             }
         }
         if (!anchor) return true;
-        
-        var href = anchor.getAttribute('href');
+
         var u = url.parse(anchor.getAttribute('href'));
         
         if (u.host && u.host !== location.host) return true;
         
         ev.preventDefault();
-        
-        var base = location.protocol + '//' + location.host;
         
         cb(url.resolve(location.pathname, u.path || '') + (u.hash || ''));
         return false;

--- a/readme.markdown
+++ b/readme.markdown
@@ -38,9 +38,9 @@ The external link to npmjs.org will go through as usual.
 ``` js
 var catchLinks = require('catch-links');
 
-catchLinks(window, function (href) {
+window.addEventListener('click', catchlinks(function (href) {
     console.log(href);
-});
+}))
 ```
 
 # methods
@@ -49,7 +49,7 @@ catchLinks(window, function (href) {
 var catchLinks = require('catch-links')
 ```
 
-## catchLinks(element, cb)
+## catchLinks(cb)
 
 Fire `cb(href)` whenever an anchor tag descendant of `element` with an in-server
 url is clicked.


### PR DESCRIPTION
I used anchor elements to handle URL parsing in order to drop the URL module dependency (dropped 3.7 KBs gzipped from my project).  Had to add some normalizing for IE.