### PR TITLE
Dropped event-binding and returned the event object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
-var url = require('url');
-
-module.exports = function (root, cb) {
-    root.addEventListener('click', function (ev) {
+module.exports = function (cb) {    
+    return function (ev) {
         if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey || ev.defaultPrevented) {
             return true;
         }
@@ -13,15 +11,23 @@ module.exports = function (root, cb) {
                 break;
             }
         }
+
         if (!anchor) return true;
+
+        // IE clears the host value if the anchor href changed after creation, e.g. in React
+        // Creating a new anchor element to insure host value is present
+        var a1 = document.createElement('a');
+        a1.href = anchor.href;
         
-        var u = url.parse(anchor.getAttribute('href'));
+        // In IE, the default port is included in the anchor host but excluded from the location host.
+        // This affects the ability to directly compare location host to anchor host.
+        // For example: http://example.com would have a location.host of 'example.com' and an anchor.host of 'example.com:80'
+        // Creating anchor from the location.href to normalize the host value.
+        var a2 = document.createElement('a');
+        a2.href = location.href;
+
+        if (a1.host !== a2.host) return true;
         
-        if (u.host && u.host !== location.host) return true;
-        
-        ev.preventDefault();
-        
-        cb(url.resolve(location.pathname, u.path || '') + (u.hash || ''));
-        return false;
-    });
+        cb(ev, anchor);
+    };
 };

--- a/readme.markdown
+++ b/readme.markdown
@@ -38,9 +38,10 @@ The external link to npmjs.org will go through as usual.
 ``` js
 var catchLinks = require('catch-links');
 
-catchLinks(window, function (href) {
-    console.log(href);
-});
+window.addEventListener('click', catchLinks(function (event, anchor) {
+  event.preventDefault();
+  console.log(anchor.href);
+}));
 ```
 
 # methods
@@ -49,12 +50,9 @@ catchLinks(window, function (href) {
 var catchLinks = require('catch-links')
 ```
 
-## catchLinks(element, cb)
+## catchLinks(cb)
 
-Fire `cb(href)` whenever an anchor tag descendant of `element` with an in-server
-url is clicked.
-
-`href` will always be a relative path rooted at the root path.
+Fire `cb(event, anchor)` whenever an anchor tag with an in-server url is clicked.
 
 # install
 


### PR DESCRIPTION
Dropped the event binding responsibility for more flexibility and because it was impossible to unbind the event.  

I also dropped cancelling the default behavior in favor of returning the event, in order to give control over cancellation.  My use-case was that I did not want to cancel the default if my router couldn't match the pathname.

Also returned the anchor element instead of the href to avoid potentially having to parse the URL again in the callback.

I don't expect this to be merged because it's such a departure, just wanted to pass it along.  Thanks!